### PR TITLE
Label would incorrectly always be set to "main".

### DIFF
--- a/deploy_conda.sh
+++ b/deploy_conda.sh
@@ -9,7 +9,7 @@
 set -eu
 set -o pipefail
 
-if [[ $TRAVIS_BRANCH = "master" ]]; then
+if [[ "$TRAVIS_BRANCH" = "master" ]]; then
     LABEL="main"
 else
     LABEL="dev"


### PR DESCRIPTION
This PR fixes a bug in the script that deploys conda packages causing packages to be uploaded to the wrong label (I hate bash)...