### PR TITLE
Fixed 2 issues of type: PYTHON_W293 throughout 1 file in repo.

### DIFF
--- a/src/gwf/plugins/touch.py
+++ b/src/gwf/plugins/touch.py
@@ -12,11 +12,11 @@ def touchfile(path):
 @click.pass_obj
 def touch(obj):
     """Touch output files to update timestamps.
-    
+
     Running this command touches all output files in the workflow such that
     their modification timestamp is updated. Touching is performed bottom-up
     such that, when done, all targets in the workflow will look completed.
-    
+
     This is useful if one or more files were accidentially deleted, but you
     don't want to re-run the workflow to recreate them.
     """


### PR DESCRIPTION
PYTHON_W293: 'Remove trailing whitespace on blank line.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.