### PR TITLE
Fixed 1 issue of type: PYTHON_F401 throughout 1 file in repo.

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 from gwf.conf import FileConfig
 
-from gwf.exceptions import GWFError, ConfigurationError
+from gwf.exceptions import ConfigurationError
 
 
 def test_load_config_from_file(tmpdir):


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        