### PR TITLE
Fix incorrect use of target name

### DIFF
--- a/src/gwf/plugins/logs.py
+++ b/src/gwf/plugins/logs.py
@@ -20,7 +20,7 @@ def logs(obj, target, stderr, no_pager):
 
     if target not in workflow.targets:
         raise WorkflowError(
-            'Target "{}" is not found in the workflow.'.format(target.name)
+            'Target "{}" is not found in the workflow.'.format(target)
         )
 
     log_file = backend_cls.logs(workflow.targets[target], stderr=stderr)


### PR DESCRIPTION
The parameter `target` is a string and not a `Target`. Therefore
`target.name` is not a valid attribute.