### PR TITLE
Added single quotes around width in mapping guide

### DIFF
--- a/docs/guide/mapping.rst
+++ b/docs/guide/mapping.rst
@@ -148,9 +148,9 @@ arguments to the function template:
 .. code-block:: python
 
     photos = [
-        {'path': 'photos/dog.jpg', width: 600},
-        {'path': 'photos/horse.jpg', width: 200},
-        {'path': 'photos/cat.jpg', width: 1000},
+        {'path': 'photos/dog.jpg', 'width': 600},
+        {'path': 'photos/horse.jpg', 'width': 200},
+        {'path': 'photos/cat.jpg', 'width': 1000},
     ]
 
     gwf.map(transform_photo, photos, name=get_photo_name)


### PR DESCRIPTION
I guess the width key ought to be a string and therefore should have quotes like the path key. So here is a commit where the quotes have been added.