### PR TITLE
Added target group

### DIFF
--- a/src/gwf/core.py
+++ b/src/gwf/core.py
@@ -1,4 +1,5 @@
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -175,6 +176,8 @@ class AnonymousTarget:
     :ivar dict options:
         Options such as number of cores, memory requirements etc. Options are
         backend-dependent. Backends will ignore unsupported options.
+    :ivar str group:
+        The group to which the target is assigned.
     :ivar str working_dir:
         Working directory of this target.
     :ivar str spec:
@@ -187,9 +190,17 @@ class AnonymousTarget:
     inputs: list = attrs.field()
     outputs: list = attrs.field()
     options: dict = attrs.field()
+    group: str = attrs.field(default=None)
     working_dir: str = attrs.field(default=".")
     protect: set = attrs.field(factory=set, converter=set)
     spec: str = attrs.field(default="")
+
+    def __attrs_post_init__(self):
+        if self.group is None:
+            self.group = (
+                inspect.stack()[2].function
+                or inspect.currentframe().f_back.f_code.co_name
+            )
 
 
 def _validate_path(instance, attribute, value):
@@ -246,6 +257,9 @@ class Target:
     :ivar str name:
         Name of the target.
 
+    :ivar str group:
+        The group to which the target is assigned.
+
     .. versionchanged:: 1.6.0
         Named inputs and outputs were added. Prior versions require *inputs*
         and *outputs* to be lists.
@@ -255,6 +269,7 @@ class Target:
     inputs: list = attrs.field(validator=_validate_path)
     outputs: list = attrs.field(validator=_validate_path)
     options: dict = attrs.field()
+    group: str = attrs.field(default=None)
     working_dir: str = attrs.field(default=".")
     protect: set = attrs.field(factory=set, converter=set)
     spec: str = attrs.field(default="")

--- a/src/gwf/workflow.py
+++ b/src/gwf/workflow.py
@@ -256,6 +256,7 @@ class Workflow:
         """
         new_target = Target(
             name=name,
+            group=template.group,
             inputs=template.inputs,
             outputs=template.outputs,
             protect=template.protect,


### PR DESCRIPTION
Added group attribute to Target and AnonymousTarget classes. The group attribute of AnonymousTarget defaults to the template function name.

The feature is useful for visualizing compact dependency graphs and has been tested on the example workflows in addition to an in-house workflow under development.

The post initiation assignment of the group attribute could potentially be removed or enhanced.

### Tests on example workflows

1. **examples/minimal-workflow**
```
{
  'SayHello': {'group': None},
  'World': {'group': None},
  'Universe': {'group': None},
  'All': {'group': None}
}
```
2. **examples/minimal-workflow-explicit-options**
```
{
  'SayHello': {'group': None},
  'World': {'group': None},
  'Universe': {'group': None},
  'All': {'group': None}
}
```

3. **examples/named-inputs-outputs**
```
{
  'Producer': {'group': None},
  'Consumer1': {'group': None},
  'Consumer2': {'group': None}
}
```

4. **examples/readmapping**
```
{
  'UnzipGenome': {'group': 'unzip'},
  'IndexGenome': {'group': 'bwa_index'},
  'MapReads': {'group': 'bwa_map'}
}
```

5. **examples/simple-workflow**
```
{
  'Target1': {'group': None},
  'Target2': {'group': None}
}
```

6. **examples/using-map**
```
{
  'filter_chromosomes_0': {'group': 'filter_chromosomes'},
  'filter_chromosomes_1': {'group': 'filter_chromosomes'},
  'filter_chromosomes_2': {'group': 'filter_chromosomes'},
  'compute_stats_0': {'group': 'compute_stats'},
  'compute_stats_1': {'group': 'compute_stats'},
  'compute_stats_2': {'group': 'compute_stats'},
  'sum_counts': {'group': 'sum_ts'},
  'compute_avg_len_0': {'group': 'compute_avg_len'},
  'compute_avg_len_1': {'group': 'compute_avg_len'},
  'compute_avg_len_2': {'group': 'compute_avg_len'}
}
```