### PR TITLE
Added the `-ti` flag to bsub command of lsf

### DIFF
--- a/src/gwf/backends/lsf.py
+++ b/src/gwf/backends/lsf.py
@@ -74,6 +74,7 @@ class LSFOps:
         if dependencies:
             args.append("-w")
             args.append(" && ".join([f"done({job_id})" for job_id in dependencies]))
+            args.append("-ti")
         logger.debug(f"Submitting job { target.name } to LSF")
         stdout = call("bsub", *args, input=script).strip()
         job_id = re.search(r"Job <(\d+)>", stdout)[1]


### PR DESCRIPTION
This change just adds the '-ti' flag to bsub, kills jobs submitted to lsf which have been orphaned (a depency has failed). See [here](https://www.ibm.com/docs/no/spectrum-lsf/10.1.0?topic=options-ti)