### PR TITLE
Add support for temporary files in targets

### DIFF
--- a/src/gwf/core.py
+++ b/src/gwf/core.py
@@ -184,6 +184,9 @@ class AnonymousTarget:
         Working directory of this target.
     :ivar str spec:
         The specification of the target.
+    :ivar set temp:
+        An iterable of temporary files which can be removed during cleaning,
+        without affecting the scheduling status of the target.
     :ivar set protect:
         An iterable of protected files which will not be removed during
         cleaning, even if this target is not an endpoint.
@@ -194,6 +197,7 @@ class AnonymousTarget:
     options: dict = attrs.field()
     group: str = attrs.field(default=None)
     working_dir: str = attrs.field(default=".")
+    temp: set = attrs.field(factory=set, converter=set)
     protect: set = attrs.field(factory=set, converter=set)
     executor: Optional[executors.Executor] = attrs.field(default=None)
     spec: str = attrs.field(default="")
@@ -274,6 +278,7 @@ class Target:
     options: dict = attrs.field()
     group: str = attrs.field(default=None)
     working_dir: str = attrs.field(default=".")
+    temp: set = attrs.field(factory=set, converter=set)
     protect: set = attrs.field(factory=set, converter=set)
     executor: executors.Executor = attrs.field(factory=executors.Bash)
     spec: str = attrs.field(default="", repr=False)
@@ -308,6 +313,9 @@ class Target:
 
     def flattened_outputs(self):
         return _norm_paths(self.working_dir, _flatten(self.outputs))
+
+    def temporary(self):
+        return set(_norm_paths(self.working_dir, _flatten(self.temp)))
 
     def protected(self):
         return set(_norm_paths(self.working_dir, _flatten(self.protect)))
@@ -393,6 +401,7 @@ class Graph:
     dependencies: defaultdict = attrs.field()
     dependents: defaultdict = attrs.field()
     unresolved: set = attrs.field()
+    temporary: set = attrs.field()
 
     @classmethod
     def from_targets(cls, targets, fs):
@@ -410,6 +419,7 @@ class Graph:
             Raised if the graph contains a circular dependency.
         """
         provides = {}
+        temporary = set()
         unresolved = set()
         dependencies = defaultdict(set)
         dependents = defaultdict(set)
@@ -430,6 +440,7 @@ class Graph:
                     provides[path] = target
 
         for target in targets:
+            temporary.update(target.temporary())
             for path in target.flattened_inputs():
                 if path in provides:
                     dependencies[target].add(provides[path])
@@ -460,6 +471,7 @@ class Graph:
             dependencies=dependencies,
             dependents=dependents,
             unresolved=unresolved,
+            temporary=temporary,
         )
 
     def endpoints(self):

--- a/src/gwf/scheduling.py
+++ b/src/gwf/scheduling.py
@@ -1,5 +1,5 @@
 import logging
-from functools import partial
+from functools import partial, lru_cache
 
 from .backends.base import BackendStatus
 from .core import Status
@@ -16,42 +16,6 @@ SUBMITTED_STATES = (
 )
 
 
-def should_run(target, fs, spec_hashes):
-    new_hash = spec_hashes.has_changed(target)
-    if new_hash is not None:
-        logger.debug("Target %s has a changed spec", target)
-        return True
-
-    for path in target.flattened_outputs():
-        if not fs.exists(path):
-            logger.debug("Target %s is missing output file %s", target, path)
-            return True
-
-    youngest_in_ts, _ = max(
-        ((fs.changed_at(path), path) for path in target.flattened_inputs()),
-        default=(float("-inf"), None),
-    )
-
-    # If I have no outputs, but I have inputs, I should probably only run if my input
-    # changed, but I don't have any output files to compare with, so I'll just run
-    # every time.
-    if not target.outputs:
-        logger.debug("Target %s has no outputs and will always be scheduled", target)
-        return True
-
-    oldest_out_ts, _ = min(
-        ((fs.changed_at(path), path) for path in target.flattened_outputs()),
-        default=(float("inf"), None),
-    )
-
-    if youngest_in_ts > oldest_out_ts:
-        logger.debug("Target %s is not up-to-date", target)
-        return True
-
-    logger.debug("Target %s is up-to-date", target)
-    return False
-
-
 def schedule(
     endpoints,
     graph,
@@ -62,6 +26,117 @@ def schedule(
     force=False,
     no_deps=False,
 ):
+    @lru_cache(maxsize=None)
+    def _non_temp_outputs(target):
+        return frozenset(target.flattened_outputs()) - graph.temporary
+
+    @lru_cache(maxsize=None)
+    def _non_temp_inputs(target):
+        return frozenset(target.flattened_inputs()) - graph.temporary
+
+    @lru_cache(maxsize=None)
+    def _oldest_output_mtime(target):
+        outputs = _non_temp_outputs(target)
+        missing = next((p for p in outputs if not fs.exists(p)), None)
+        if missing is not None:
+            return None, missing
+        return min((fs.changed_at(p) for p in outputs), default=float("inf")), None
+
+    @lru_cache(maxsize=None)
+    def _youngest_input_mtime(target):
+        inputs = _non_temp_inputs(target)
+        first_missing = next((p for p in inputs if not fs.exists(p)), None)
+        existing = [p for p in inputs if fs.exists(p)]
+        youngest = max((fs.changed_at(p) for p in existing), default=float("-inf"))
+        return youngest, first_missing
+
+    @lru_cache(maxsize=None)
+    def _dependents_are_up_to_date(target):
+        if not (dependents := graph.dependents[target]):
+            return False
+        for dep in dependents:
+            if _non_temp_outputs(dep):
+                oldest_out, _ = _oldest_output_mtime(dep)
+                if oldest_out is None:
+                    return False
+                youngest_in, _ = _youngest_input_mtime(dep)
+                if youngest_in > oldest_out:
+                    return False
+            elif not _dependents_are_up_to_date(dep):
+                return False
+        return True
+
+    @lru_cache(maxsize=None)
+    def _should_run(target):
+        if spec_hashes.has_changed(target) is not None:
+            logger.debug("Target %s has a changed spec", target)
+            return True
+
+        # If I have no outputs, but I have inputs, I should probably only run if my input
+        # changed, but I don't have any output files to compare with, so I'll just run
+        # every time.
+        if not target.outputs:
+            logger.debug(
+                "Target %s has no outputs and will always be scheduled", target
+            )
+            return True
+
+        non_temp = _non_temp_outputs(target)
+        temp_outputs = frozenset(target.flattened_outputs()) - non_temp
+
+        # If I have non-temporary outputs, I should run if any of them are missing, or if any
+        # existing input is newer than any existing output.
+        if non_temp:
+            oldest_out, missing_out = _oldest_output_mtime(target)
+            if oldest_out is None:
+                logger.debug("Target %s is missing output file %s", target, missing_out)
+                return True
+
+            youngest_in, missing_in = _youngest_input_mtime(target)
+            if missing_in is not None:
+                logger.debug("Target %s is missing input file %s", target, missing_in)
+                return True
+
+            if youngest_in > oldest_out:
+                logger.debug("Target %s is not up-to-date", target)
+                return True
+
+            logger.debug("Target %s is up-to-date", target)
+            return False
+
+        # If I have only temporary outputs and any of them are missing, I should run if any downstream
+        # targets are missing outputs or have newer inputs, otherwise I can consider myself up-to-date.
+        missing_temp = next((p for p in temp_outputs if not fs.exists(p)), None)
+        if missing_temp is not None:
+            if _dependents_are_up_to_date(target):
+                logger.debug(
+                    "Target %s has missing temporary outputs but all downstream outputs exist and are up-to-date",
+                    target,
+                )
+                return False
+
+            logger.debug(
+                "Target %s is missing temporary output file %s",
+                target,
+                missing_temp,
+            )
+            return True
+
+        # If I have only temporary outputs and none of them are missing, I should run if any existing input
+        # is newer than any existing output.
+        oldest_temp = min(
+            (fs.changed_at(p) for p in temp_outputs), default=float("inf")
+        )
+        if any(
+            fs.exists(p) and fs.changed_at(p) > oldest_temp
+            for p in target.flattened_inputs()
+        ):
+            logger.debug("Target %s (temp outputs) is not up-to-date", target)
+            return True
+
+        logger.debug("Target %s is up-to-date", target)
+        return False
+
     def _schedule(target):
         submitted_deps = []
 
@@ -101,7 +176,7 @@ def schedule(
             submit_func(target, dependencies=submitted_deps)
             return Status.SHOULDRUN
 
-        if should_run(target, fs, spec_hashes):
+        if _should_run(target):
             submit_func(target, dependencies=submitted_deps)
             return Status.SHOULDRUN
 

--- a/src/gwf/workflow.py
+++ b/src/gwf/workflow.py
@@ -201,7 +201,15 @@ class Workflow:
         self.targets[target.name] = target
 
     def target(
-        self, name, inputs, outputs, protect=None, group=None, executor=None, **options
+        self,
+        name,
+        inputs,
+        outputs,
+        temp=None,
+        protect=None,
+        group=None,
+        executor=None,
+        **options,
     ):
         """Create a target and add it to the :class:`gwf.Workflow`.
 
@@ -229,6 +237,7 @@ class Workflow:
             name=name,
             inputs=inputs,
             outputs=outputs,
+            temp=temp if temp else set(),
             protect=protect if protect else set(),
             group=group,
             executor=executor or self.executor,
@@ -266,6 +275,7 @@ class Workflow:
             name=name,
             inputs=template.inputs,
             outputs=template.outputs,
+            temp=template.temp,
             protect=template.protect,
             group=template.group,
             executor=template.executor or self.executor,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,9 @@ class FakeFilesystem:
     def add_file(self, path, changed_at):
         self.files[path] = changed_at
 
+    def remove_file(self, path):
+        del self.files[path]
+
     def exists(self, path):
         return path in self.files
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -497,3 +497,168 @@ def test_scheduling_with_spec_hashing(backend, spec_hashes, filesystem):
         spec_hashes=spec_hashes,
     )
     assert target_states[target] == Status.SHOULDRUN
+
+
+def test_scheduling_graph_with_multiple_temporary_files(filesystem, backend):
+    """Test scheduling with multiple temporary files."""
+
+    target1 = Target(
+        "TestTarget1",
+        inputs=[],
+        outputs=["temp_output1.txt"],
+        options={},
+        working_dir="/some/dir",
+        temp={"temp_output1.txt"},
+    )
+    target2 = Target(
+        "TestTarget2",
+        inputs=["temp_output1.txt"],
+        outputs=["temp_output2.txt"],
+        options={},
+        working_dir="/some/dir",
+        temp={"temp_output2.txt"},
+    )
+    target3 = Target(
+        "TestTarget3",
+        inputs=["temp_output1.txt"],
+        outputs=["temp_output3.txt", "intermediate_output1.txt"],
+        options={},
+        working_dir="/some/dir",
+        temp={"temp_output3.txt"},
+    )
+    target4 = Target(
+        "TestTarget4",
+        inputs=["temp_output2.txt", "intermediate_output1.txt"],
+        outputs=["intermediate_output2.txt"],
+        options={},
+        working_dir="/some/dir",
+    )
+    target5 = Target(
+        "TestTarget5",
+        inputs=["intermediate_output1.txt", "intermediate_output2.txt"],
+        outputs=["final_output1.txt"],
+        options={},
+        working_dir="/some/dir",
+    )
+    target6 = Target(
+        "TestTarget6",
+        inputs=["temp_output3.txt", "intermediate_output2.txt"],
+        outputs=["final_output2.txt"],
+        options={},
+        working_dir="/some/dir",
+    )
+    graph = Graph.from_targets(
+        [target1, target2, target3, target4, target5, target6], filesystem
+    )
+
+    # All targets should run when nothing exists
+    target_states = get_status_map(
+        graph=graph,
+        endpoints=[target5, target6],
+        fs=filesystem,
+        backend=backend,
+        spec_hashes=NoopSpecHashes(),
+    )
+    assert target_states[target1] == Status.SHOULDRUN
+    assert target_states[target2] == Status.SHOULDRUN
+    assert target_states[target3] == Status.SHOULDRUN
+    assert target_states[target4] == Status.SHOULDRUN
+    assert target_states[target5] == Status.SHOULDRUN
+    assert target_states[target6] == Status.SHOULDRUN
+
+    # Add all files
+    filesystem.add_file("/some/dir/temp_output1.txt", changed_at=0)
+    filesystem.add_file("/some/dir/temp_output2.txt", changed_at=1)
+    filesystem.add_file("/some/dir/temp_output3.txt", changed_at=2)
+    filesystem.add_file("/some/dir/intermediate_output1.txt", changed_at=2)
+    filesystem.add_file("/some/dir/intermediate_output2.txt", changed_at=3)
+
+    # All non-endpoint targets should be completed
+    target_states = get_status_map(
+        graph=graph,
+        endpoints=[target5, target6],
+        fs=filesystem,
+        backend=backend,
+        spec_hashes=NoopSpecHashes(),
+    )
+    assert target_states[target1] == Status.COMPLETED
+    assert target_states[target2] == Status.COMPLETED
+    assert target_states[target3] == Status.COMPLETED
+    assert target_states[target4] == Status.COMPLETED
+    assert target_states[target5] == Status.SHOULDRUN
+    assert target_states[target6] == Status.SHOULDRUN
+
+    # Add final output file
+    filesystem.add_file("/some/dir/final_output1.txt", changed_at=4)
+    filesystem.add_file("/some/dir/final_output2.txt", changed_at=4)
+
+    # All targets should be completed
+    target_states = get_status_map(
+        graph=graph,
+        endpoints=[target5, target6],
+        fs=filesystem,
+        backend=backend,
+        spec_hashes=NoopSpecHashes(),
+    )
+    assert target_states[target1] == Status.COMPLETED
+    assert target_states[target2] == Status.COMPLETED
+    assert target_states[target3] == Status.COMPLETED
+    assert target_states[target4] == Status.COMPLETED
+    assert target_states[target5] == Status.COMPLETED
+    assert target_states[target6] == Status.COMPLETED
+
+    # Remove temporary files
+    filesystem.remove_file("/some/dir/temp_output1.txt")
+    filesystem.remove_file("/some/dir/temp_output2.txt")
+    filesystem.remove_file("/some/dir/temp_output3.txt")
+
+    # All targets should be completed
+    target_states = get_status_map(
+        graph=graph,
+        endpoints=[target5, target6],
+        fs=filesystem,
+        backend=backend,
+        spec_hashes=NoopSpecHashes(),
+    )
+    assert target_states[target1] == Status.COMPLETED
+    assert target_states[target2] == Status.COMPLETED
+    assert target_states[target3] == Status.COMPLETED
+    assert target_states[target4] == Status.COMPLETED
+    assert target_states[target5] == Status.COMPLETED
+    assert target_states[target6] == Status.COMPLETED
+
+    # Remove output from an endpoint target
+    filesystem.remove_file("/some/dir/final_output1.txt")
+
+    # Only target5 should run
+    target_states = get_status_map(
+        graph=graph,
+        endpoints=[target5, target6],
+        fs=filesystem,
+        backend=backend,
+        spec_hashes=NoopSpecHashes(),
+    )
+    assert target_states[target1] == Status.COMPLETED
+    assert target_states[target2] == Status.COMPLETED
+    assert target_states[target3] == Status.COMPLETED
+    assert target_states[target4] == Status.COMPLETED
+    assert target_states[target5] == Status.SHOULDRUN
+    assert target_states[target6] == Status.COMPLETED
+
+    # Remove intermediate output file that all endpoint targets depend on
+    filesystem.remove_file("/some/dir/intermediate_output2.txt")
+
+    # All targets targets should run
+    target_states = get_status_map(
+        graph=graph,
+        endpoints=[target5, target6],
+        fs=filesystem,
+        backend=backend,
+        spec_hashes=NoopSpecHashes(),
+    )
+    assert target_states[target1] == Status.SHOULDRUN
+    assert target_states[target2] == Status.SHOULDRUN
+    assert target_states[target3] == Status.SHOULDRUN
+    assert target_states[target4] == Status.SHOULDRUN
+    assert target_states[target5] == Status.SHOULDRUN
+    assert target_states[target6] == Status.SHOULDRUN


### PR DESCRIPTION
Most workflows produce intermediate/temporary files that should be deleted upon workflow completion. Currently, gwf has no concept of temporary files, as deleting intermediate files will trigger a rerun. In production workflows, an accidental workflow rerun will compromise the data integrity.

This PR constitutes a rework of the core temporary files implementation from #426.

The proposed feature is a `temp` field in the `Target` class that users can use to apply special behavior to specified intermediate files during scheduling.