### PR TITLE
pbs: honour walltime and account target options

### DIFF
--- a/src/gwf/backends/pbs.py
+++ b/src/gwf/backends/pbs.py
@@ -14,8 +14,14 @@ None.
     Number of cores allocated to this target (default: 1).
 * **memory (str):**
     Memory allocated to this target (default: 4GB).
+* **walltime (str):**
+    Wall-clock time limit, ``HH:MM:SS`` (default: ``01:00:00``). Emitted as
+    ``#PBS -l walltime=...``.
 * **queue (str):**
     Queue to submit the target to (default: normal).
+* **account (str):**
+    Accounting/group string for the job (default: unset). When set, emitted
+    as ``#PBS -A <account>``; when empty the directive is omitted entirely.
 
 """
 
@@ -32,10 +38,17 @@ from .utils import call, has_exe
 
 logger = logging.getLogger(__name__)
 
-TARGET_DEFAULTS = {"queue": "normal", "memory": "4GB", "cores": 1}
+TARGET_DEFAULTS = {
+    "queue": "normal",
+    "memory": "4GB",
+    "cores": 1,
+    "walltime": "01:00:00",
+    "account": "",
+}
 
 PBS_HEADER = """#PBS -l mem={memory}
 #PBS -l nodes=1:ppn={cores}
+#PBS -l walltime={walltime}
 #PBS -q {queue}
 #PBS -o {std_out}
 #PBS -e {std_err}
@@ -100,6 +113,11 @@ class PBSOps:
         for name, value in target_options.items():
             header = header.replace(f"{{{name}}}", str(value))
         header = header.replace("{job_name}", target.name)
+        # Optional accounting directive. PBS rejects an empty argument to -A,
+        # so the line is appended only when an account is actually configured.
+        account = str(target_options.get("account", "")).strip()
+        if account:
+            header += f"\n#PBS -A {account}"
         out = []
         out.append("#!/bin/bash")
         out.append(header)


### PR DESCRIPTION
The PBS backend's `TARGET_DEFAULTS` currently lists only `queue`, `memory`,
and `cores`. Any target that sets `walltime` or `account` triggers the
"Option X not supported by backend. Ignored." warning and qsub falls back
to the cluster's default walltime / no accounting. On sites with short
defaults this silently kills long-running jobs; on sites that require an
account string for billing, jobs can't be submitted at all.

Both options are already standard on the SLURM backend, and PBS itself
universally supports `#PBS -l walltime=...` and `#PBS -A <account>`
(Torque, OpenPBS, PBS Pro).

Changes:

* `walltime` added to `TARGET_DEFAULTS` (default `01:00:00`) and emitted
  as `#PBS -l walltime={walltime}`.
* `account` added to `TARGET_DEFAULTS` (default `""`) with conditional
  emission in `compile_script` - the `-A` line is omitted entirely when
  no account is configured, so sites that don't use accounting are
  unaffected.
* Docstring updated.

Tested under OpenPBS/Moab at the Danish National Genome Center
