### PR TITLE
LSF job state

### DIFF
--- a/src/gwf/backends/lsf.py
+++ b/src/gwf/backends/lsf.py
@@ -31,11 +31,10 @@ from .utils import call, has_exe
 
 logger = logging.getLogger(__name__)
 
-TARGET_DEFAULTS = {"queue": "normal", "memory": "4GB", "cores": 1, "resource": ""}
+TARGET_DEFAULTS = {"queue": "normal", "memory": "4GB", "cores": 1}
 
 BJOB_HEADER = """#BSUB -M {memory}
 #BSUB -R "select[mem>{memory}] rusage[mem={memory}] span[hosts=1]"
-#BSUB -R {resource}
 #BSUB -n {cores}
 #BSUB -q {queue}
 #BSUB -oo {std_out}

--- a/src/gwf/backends/lsf.py
+++ b/src/gwf/backends/lsf.py
@@ -31,10 +31,11 @@ from .utils import call, has_exe
 
 logger = logging.getLogger(__name__)
 
-TARGET_DEFAULTS = {"queue": "normal", "memory": "4GB", "cores": 1}
+TARGET_DEFAULTS = {"queue": "normal", "memory": "4GB", "cores": 1, "resource": ""}
 
 BJOB_HEADER = """#BSUB -M {memory}
 #BSUB -R "select[mem>{memory}] rusage[mem={memory}] span[hosts=1]"
+#BSUB -R {resource}
 #BSUB -n {cores}
 #BSUB -q {queue}
 #BSUB -oo {std_out}
@@ -80,14 +81,15 @@ class LSFOps:
         logger.debug("Getting job states from LSF")
         if not tracked_jobs:
             return {}
+        # Default tracked job IDs to UNKNOWN
         job_states = {job_id: BackendStatus.UNKNOWN for job_id in tracked_jobs}
-        for job_id in tracked_jobs:
-            cmd = ["bjobs", "-noheader", "-o", "stat", job_id]
-            ret = call(*cmd).strip()
-            if ret == "":
-                continue
-            state = BJOB_STATES[ret]
-            job_states[job_id] = state
+
+        # Get all current job statuses
+        for line in call("bjobs", "-noheader", "-o" , "jobid stat delimiter=','").splitlines():
+            job_id, state = line.strip().split(",")
+            # Update job status if tracked
+            if job_id in tracked_jobs:
+                job_states[job_id] = BJOB_STATES[state]
         return job_states
 
     def compile_script(self, target):


### PR DESCRIPTION
The current approach of creating a subprocess to run and capture the output of `bjobs <jobid>` for every tracked job is very slow when dealing with large numbers of targets.

Calling `bjobs` will only return Submitted, Suspended, Running and Unknown jobs, so this does remove the ability to capture Failed jobs - although, this information is only returned from `bjobs <jobid>` in a very short window after the jobs has finished, so in practice I think this is the better approach overall.

Changes:
- The  get_job_states function in the lsf backend

Tested on the LSF HPC at the Wellcome Sanger Institute

Thanks for your work on GWF!